### PR TITLE
Add `unique-0` to `stack.yaml`

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,2 @@
 resolver: nightly-2015-09-20
+extra-deps: [unique-0]


### PR DESCRIPTION
I was unable to build the project with the resolver alone.  I had to add `unique-0` as an `extra-dep` to complete the build.
