### PR TITLE
Fix broken link for "The Art of the Propagator"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ propagators
 
 Propagators propagate increases in information from cell to cell.
 
-They are described (using Scheme) in Alexey Radul and Gerald Sussman's ["The Art of the Propagator"](http://web.mit.edu/~axch/www/art.pdf) as well as in Alexey Radul's thesis on [Propagation Networks](http://groups.csail.mit.edu/genesis/papers/radul%202009.pdf).
+They are described (using Scheme) in Alexey Radul and Gerald Sussman's ["The Art of the Propagator"](https://dspace.mit.edu/bitstream/handle/1721.1/44215/MIT-CSAIL-TR-2009-002.pdf) as well as in Alexey Radul's thesis on [Propagation Networks](http://groups.csail.mit.edu/genesis/papers/radul%202009.pdf).
 
 This package explores design options for propagators in Haskell. The primary innovation here (beyond the published work) is the use of observable sharing to let us take a more direct form of programming and transform it back and forth to the propagator style.
 


### PR DESCRIPTION
The current link seems broken so I've assume that [this one](https://dspace.mit.edu/bitstream/handle/1721.1/44215/MIT-CSAIL-TR-2009-002.pdf) is correct.
