### PR TITLE
A pure alternative to Prop.hs

### DIFF
--- a/propagators.cabal
+++ b/propagators.cabal
@@ -1,8 +1,8 @@
+cabal-version: 3.6
 name:          propagators
 category:      Data
 version:       0
-license:       BSD3
-cabal-version: >= 1.22
+license:       BSD-3-Clause
 license-file:  LICENSE
 author:        Edward A. Kmett
 maintainer:    Edward A. Kmett <ekmett@gmail.com>
@@ -10,7 +10,7 @@ stability:     experimental
 homepage:      http://github.com/ekmett/propagators/
 bug-reports:   http://github.com/ekmett/propagators/issues
 copyright:     Copyright (C) 2015 Edward A. Kmett
-build-type:    Custom
+build-type:    Simple
 tested-with:   GHC == 7.10.2
 synopsis:      The Art of the Propagator
 description:   <http://web.mit.edu/~axch/www/art.pdf The Art of the Propagator>
@@ -38,9 +38,9 @@ library
     base >= 4.8 && < 5,
     data-reify >= 0.6 && < 7,
     ghc-prim,
-    hashable >= 1.2 && < 1.3,
+    hashable >= 1.2 && < 1.5,
     intervals >= 0.7 && < 0.9,
-    primitive >= 0.5 && < 0.7,
+    primitive >= 0.5 && < 0.8,
     unique >= 0 && < 0.1,
     unordered-containers >= 0.2 && < 0.3
 
@@ -52,6 +52,8 @@ library
     Data.Propagator.Num
     Data.Propagator.Prop
     Data.Propagator.Supported
+    Data.Propagator.Thunk
+    Data.Propagator.PProp
 
   ghc-options: -Wall -fwarn-tabs
 

--- a/src/Data/Propagator/Name.hs
+++ b/src/Data/Propagator/Name.hs
@@ -18,9 +18,8 @@ import Control.Monad.Primitive
 import Data.Bits
 import Data.Hashable
 import Data.String
-import GHC.Prim
 import System.Mem.StableName
-import GHC.Exts(Any)
+import GHC.Exts(Any, unsafeCoerce#)
 
 data Name
   = U {-# UNPACK #-} !Unique

--- a/src/Data/Propagator/PProp.hs
+++ b/src/Data/Propagator/PProp.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingVia #-}
+-- | An alternative to "Data.Propagator.Prop".
+module Data.Propagator.PProp where
+
+import System.IO.Unsafe
+import Control.Monad.ST
+import Data.Monoid
+import Data.Coerce
+
+import Data.Propagator.Class
+import Data.Propagator.Cell
+import Data.Propagator.Thunk
+
+-- At least for my example, I do not want empty cells (because (&&) can
+-- propagate information even if one argument is still unknown) so lets
+-- only work with lattices with bottom
+class Propagated a => HasBottom a where
+    bottom :: a
+instance (Eq a, Monoid a) =>  HasBottom (MergeUsingSemigroup a) where
+    bottom = MergeUsingSemigroup mempty
+deriving via MergeUsingSemigroup Any instance HasBottom Any
+deriving via MergeUsingSemigroup All instance HasBottom All
+
+data PProp a where
+    PProp :: Cell RealWorld a -> Thunk -> PProp a
+
+defineConst :: HasBottom a => a -> PProp a
+defineConst x = unsafePerformIO $ do
+    c <- stToIO $ known x
+    t <- doneThunk
+    pure (PProp c t)
+
+defineUnary :: HasBottom b => (a -> b) -> PProp a -> PProp b
+defineUnary f p = unsafePerformIO $ do
+    c <- stToIO $ known bottom
+    t <- thunk $ do
+        -- NB: Only peek at p inside thunk
+        let PProp c1 t1 = p
+        stToIO $ lift1 f c1 c
+        mapM kick [t1]
+    pure (PProp c t)
+
+defineBinary :: HasBottom c => (a -> b -> c) -> PProp a -> PProp b -> PProp c
+defineBinary f p1 p2 = unsafePerformIO $ do
+    c <- stToIO $ known bottom
+    t <- thunk $ do
+        let PProp c1 t1 = p1
+        let PProp c2 t2 = p2
+        stToIO $ lift2 f c1 c2 c
+        mapM kick [t1, t2]
+    pure (PProp c t)
+
+-- could also do a
+--   defineNary :: Propagated c => ([a] -> c) -> [PProp a] -> PProp c
+-- if we add a liftN in Cell.hs
+
+getPProp :: PProp a -> Maybe a
+getPProp (PProp c t) = unsafePerformIO $ do
+    force t
+    stToIO $ content c
+
+
+-- A little demo with the two point lattice True < False
+
+-- This is a bit off, because we are not really using the fact that an empty
+-- cell corresponds to a cell with bottom (value True), hence we have to handle that in getPProp
+
+newtype PAll = PAll (PProp All)
+pTrue :: PAll
+pTrue = PAll (defineConst (All True))
+pFalse :: PAll
+pFalse = PAll (defineConst (All False))
+
+(&&&) :: PAll -> PAll -> PAll
+PAll p1 &&& PAll p2 = PAll (defineBinary (coerce (&&)) p1 p2)
+
+pand :: [PAll] -> PAll
+pand = foldr (&&&) pTrue
+
+getPAll :: PAll -> Bool
+getPAll (PAll p) = maybe True getAll (getPProp p)
+
+examples :: [Bool]
+examples =
+  [ (let x = pand [y]; y = pand [x, pFalse] in getPAll x) == False
+  , (let x = pand [y]; y = pand [x, pTrue]  in getPAll x) == True
+  , (let x = pand [y]; y = pand [x]         in getPAll x) == True
+  ]

--- a/src/Data/Propagator/Thunk.hs
+++ b/src/Data/Propagator/Thunk.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE LambdaCase #-}
+
+{-|
+
+The 'Thunk' API provides a way to defer potentially recursive computations:
+
+* 'thunk' is lazy in its argument, and does not run it directly
+* the fist 'kick' triggers execution of the action passed to thunk
+* that action is run at most once
+* 'force' triggers execution of the action passed to thunk, and does not return until
+  *  the action is executed
+  *  the action of any thunk kicked by the action is executed, etc.
+* Cycles are allowed: The action passed to 'thunk' may 'kick' that 'thunk'. Same for larger loops.
+
+The implementation is hopefully thread safe: Even if multiple threads force or kick related thunks, all actions are still run at most once, and all calls to force terminate (no deadlock)
+-}
+module Data.Propagator.Thunk
+    ( Thunk
+    , KickedThunk
+    , thunk
+    , doneThunk
+    , kick
+    , force
+    )
+where
+
+import Control.Concurrent
+
+newtype Thunk = Thunk (MVar (Either (IO [KickedThunk]) KickedThunk))
+data ResolvingState = NotStarted | ProcessedBy ThreadId (MVar ()) | Done
+data KickedThunk = KickedThunk (MVar [KickedThunk]) (MVar ResolvingState)
+
+thunk :: IO [KickedThunk] -> IO Thunk
+thunk act = Thunk <$> newMVar (Left act)
+
+doneThunk :: IO Thunk
+doneThunk = do
+    mv_ts <- newMVar []
+    mv_s <- newMVar Done
+    Thunk <$> newMVar (Right (KickedThunk mv_ts mv_s))
+
+-- Recursively explores the thunk, and kicks the execution
+-- May return before before execution is done (if started by another thread)
+kick :: Thunk -> IO KickedThunk
+kick (Thunk t) = takeMVar t >>= \case
+    Left act -> do
+        mv_thunks <- newEmptyMVar
+        mv_state <- newMVar NotStarted
+        let kt = KickedThunk mv_thunks mv_state
+        putMVar t (Right kt)
+
+        kts <- act
+        putMVar mv_thunks kts
+        pure kt
+
+    -- Thread was already kicked, nothing to do
+    Right kt -> do
+        putMVar t (Right kt)
+        pure kt
+
+wait :: KickedThunk -> IO ()
+wait (KickedThunk mv_deps mv_s) = do
+    my_id <- myThreadId
+    s <- takeMVar mv_s
+    case s of
+        -- Thunk and all dependences are done
+        Done -> putMVar mv_s s
+        -- Thunk is being processed by a higher priority thread, so simply wait
+        ProcessedBy other_id done_mv | other_id < my_id -> do
+            putMVar mv_s s
+            readMVar done_mv
+        -- Thunk is already being processed by this thread, ignore
+        ProcessedBy other_id _done_mv | other_id == my_id -> do
+            putMVar mv_s s
+            pure ()
+        -- Thunk is not yet processed, or processed by a lower priority thread, so process now
+        _ -> do
+            done_mv <- newEmptyMVar
+            putMVar mv_s (ProcessedBy my_id done_mv)
+            ts <- readMVar mv_deps
+            mapM_ wait ts
+            -- Mark kicked thunk as done
+            _ <- swapMVar mv_s Done
+            -- Wake up waiting threads
+            putMVar done_mv ()
+
+force :: Thunk -> IO ()
+force t = do
+    rt <- kick t
+    wait rt


### PR DESCRIPTION
This PR explores an alternative to let the user construct and query propagator networks using pure functional and possibly recursive code. I first described the ideas in <https://discourse.haskell.org/t/solving-cyclic-boolean-implications-with-pure-code-and-laziness/4951>, where I have had a rudimentary implementation of propagators (with just a two-point lattice), but I think it generalizes to many more propagator networks.

It is easier to use than `Prop`, I think (no type parameters to discharge), but less powerful (need to give all inputs to a cell at once).

The `PProp.hs` has an implementation of the final `pTrue`/`pFalse`/`pand`/`getPBool` example from my forum post, and it seems to work fine:
```
  [ (let x = pand [y]; y = pand [x, pFalse] in getPAll x) == False
  , (let x = pand [y]; y = pand [x, pTrue]  in getPAll x) == True
  , (let x = pand [y]; y = pand [x]         in getPAll x) == True
  ]
```